### PR TITLE
Allows JSON unserializing to be associative or object

### DIFF
--- a/lib/internal/Magento/Framework/Serialize/Serializer/Json.php
+++ b/lib/internal/Magento/Framework/Serialize/Serializer/Json.php
@@ -32,9 +32,9 @@ class Json implements SerializerInterface
      * @inheritDoc
      * @since 100.2.0
      */
-    public function unserialize($string)
+    public function unserialize($string, $assoc = true)
     {
-        $result = json_decode($string, true);
+        $result = json_decode($string, $assoc);
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new \InvalidArgumentException("Unable to unserialize value. Error: " . json_last_error_msg());
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Allows a developer to pass an optional boolean argument when deserializing a JSON string, so it can be returned as object or associative. Keeps associative as default for backwards compatibility.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create code that unserializes json string while passing the extra argument of false

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
